### PR TITLE
Fix Dockerfile for anaconda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
 COPY caffe.patch /tmp/caffe.patch
 
 ENV CAFFE_REVISION cc521a0801143c242f5da0e95737070c02ce15ab
-RUN git clone --depth 1 https://github.com/BVLC/caffe.git /opt/caffe \
+RUN git clone https://github.com/BVLC/caffe.git /opt/caffe \
   && cd /opt/caffe \
   && git reset --hard $CAFFE_REVISION \
   && patch -p1 < /tmp/caffe.patch \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/anaconda
+FROM continuumio/anaconda:5.1.0
 
 RUN chmod a+rwx /home
 


### PR DESCRIPTION
Addresses two problems I found while trying to build this.

1. The chmod and apt-get commands in the Dockerfile stopped working. My guess is they switched the latest Anaconda to BusyBox. I used the tag of an older version in the FROM and this seems to have fixed that problem.

1.  The script resets the cafe repo to a specific version and that version is no longer pulled by depth=1 so I removed that parameter from the clone.

